### PR TITLE
allow a tag to be passed into `skaffold run` on the CLI

### DIFF
--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -58,6 +58,7 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 }
 
 func AddRunDevFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&opts.CustomTag, "tag", "t", "", "The optional custom tag to use for images which overrides the current Tagger configuration")
 	cmd.Flags().StringVarP(&filename, "filename", "f", "skaffold.yaml", "Filename of pipeline file")
 	cmd.Flags().BoolVar(&opts.Notification, "toot", false, "Emit a terminal beep after the deploy is complete")
 }

--- a/cmd/skaffold/app/cmd/cmd.go
+++ b/cmd/skaffold/app/cmd/cmd.go
@@ -58,7 +58,6 @@ func NewSkaffoldCommand(out, err io.Writer) *cobra.Command {
 }
 
 func AddRunDevFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&opts.CustomTag, "tag", "t", "", "The optional custom tag to use for images which overrides the current Tagger configuration")
 	cmd.Flags().StringVarP(&filename, "filename", "f", "skaffold.yaml", "Filename of pipeline file")
 	cmd.Flags().BoolVar(&opts.Notification, "toot", false, "Emit a terminal beep after the deploy is complete")
 }

--- a/cmd/skaffold/app/cmd/run.go
+++ b/cmd/skaffold/app/cmd/run.go
@@ -35,5 +35,7 @@ func NewCmdRun(out io.Writer) *cobra.Command {
 		Args: cobra.NoArgs,
 	}
 	AddRunDevFlags(cmd)
+
+	cmd.Flags().StringVarP(&opts.CustomTag, "tag", "t", "", "The optional custom tag to use for images which overrides the current Tagger configuration")
 	return cmd
 }

--- a/pkg/skaffold/build/tag/custom.go
+++ b/pkg/skaffold/build/tag/custom.go
@@ -14,15 +14,24 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package config
+package tag
 
-import "io"
+import (
+	"fmt"
+)
 
-// SkaffoldOptions are options that are set by command line arguments not included
-// in the config file itself
-type SkaffoldOptions struct {
-	DevMode      bool
-	Notification bool
-	CustomTag    string
-	Output       io.Writer
+type CustomTag struct {
+	Tag string
+}
+
+// GenerateFullyQualifiedImageName tags an image with the custom tag
+func (c *CustomTag) GenerateFullyQualifiedImageName(opts *TagOptions) (string, error) {
+	if opts == nil {
+		return "", fmt.Errorf("Tag options not provided")
+	}
+	tag := c.Tag
+	if tag == "" {
+		return "", fmt.Errorf("Custom tag not provided")
+	}
+	return fmt.Sprintf("%s:%s", opts.ImageName, tag), nil
 }

--- a/pkg/skaffold/build/tag/custom_test.go
+++ b/pkg/skaffold/build/tag/custom_test.go
@@ -14,15 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package config
+package tag
 
-import "io"
+import (
+	"testing"
 
-// SkaffoldOptions are options that are set by command line arguments not included
-// in the config file itself
-type SkaffoldOptions struct {
-	DevMode      bool
-	Notification bool
-	CustomTag    string
-	Output       io.Writer
+	"github.com/GoogleCloudPlatform/skaffold/testutil"
+)
+
+func TestCustomTag_GenerateFullyQualifiedImageName(t *testing.T) {
+	opts := &TagOptions{
+		ImageName: "test",
+		Digest:    "sha256:12345abcde",
+	}
+
+	expectedTag := "1.2.3-beta"
+
+	c := &CustomTag{
+		Tag: expectedTag,
+	}
+	tag, err := c.GenerateFullyQualifiedImageName(opts)
+	testutil.CheckErrorAndDeepEqual(t, false, err, "test:"+expectedTag, tag)
 }

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -62,6 +62,12 @@ func NewForConfig(opts *config.SkaffoldOptions, cfg *config.SkaffoldConfig) (*Sk
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing skaffold tag config")
 	}
+	customTag := opts.CustomTag
+	if customTag != "" {
+		tagger = &tag.CustomTag{
+			Tag: customTag,
+		}
+	}
 	client, err := kubernetesClient()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting k8s client")


### PR DESCRIPTION
so when creating releases users can have more control over the image tags used
fixes #152