### PR TITLE
Local builder: handle build-args

### DIFF
--- a/pkg/skaffold/build/local.go
+++ b/pkg/skaffold/build/local.go
@@ -99,6 +99,7 @@ func (l *LocalBuilder) Run(out io.Writer, tagger tag.Tagger, artifacts []*config
 			ContextDir:  artifact.Workspace,
 			ProgressBuf: out,
 			BuildBuf:    out,
+			BuildArgs:   artifact.BuildArgs,
 		})
 		if err != nil {
 			return nil, errors.Wrap(err, "running build")

--- a/pkg/skaffold/config/config.go
+++ b/pkg/skaffold/config/config.go
@@ -98,9 +98,10 @@ type HelmRelease struct {
 // Artifact represents items that need should be built, along with the context in which
 // they should be built.
 type Artifact struct {
-	ImageName      string `yaml:"imageName"`
-	DockerfilePath string `yaml:"dockerfilePath"`
-	Workspace      string `yaml:"workspace"`
+	ImageName      string             `yaml:"imageName"`
+	DockerfilePath string             `yaml:"dockerfilePath"`
+	Workspace      string             `yaml:"workspace"`
+	BuildArgs      map[string]*string `yaml:"buildArgs"`
 }
 
 // DefaultDevSkaffoldConfig is a partial set of defaults for the SkaffoldConfig

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -40,6 +40,7 @@ type BuildOptions struct {
 	ContextDir  string
 	ProgressBuf io.Writer
 	BuildBuf    io.Writer
+	BuildArgs   map[string]*string
 }
 
 // RunBuild performs a docker build and returns nothing
@@ -48,6 +49,7 @@ func RunBuild(cli client.ImageAPIClient, opts *BuildOptions) error {
 	imageBuildOpts := types.ImageBuildOptions{
 		Tags:       []string{opts.ImageName},
 		Dockerfile: opts.Dockerfile,
+		BuildArgs:  opts.BuildArgs,
 		// TODO(@r2d4): Currently works, but is really slow,
 		// figure out how to get all private registry tokens in faster way
 		//


### PR DESCRIPTION
Hi,

This a small PR that allows `skaffold` to handle [`build-args`](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables-build-arg).

Example:

**Dockerfile**
```Dockerfile
FROM golang:1.9.4-alpine3.7
ARG APP_NAME
WORKDIR /go/src/github.com/GoogleCloudPlatform/skaffold/examples/getting-started
CMD ["./$APP_NAME"]
COPY main.go .
RUN go build -o $APP_NAME main.go
```

**skaffold.yaml**
```yaml
apiVersion: skaffold/v1
kind: Config
build:
  artifacts:
  - imageName: changeme # gcr.io/k8s-skaffold/skaffold-example
    workspace: examples/getting-started
    buildArgs:
      APP_NAME: app
  local: {}
deploy:
  kubectl:
    - paths:
      - examples/getting-started/k8s-*
      parameters:
        IMAGE_NAME: changeme # gcr.io/k8s-skaffold/skaffold-example
```