### PR TITLE
Helm deployer: namespace & values file

### DIFF
--- a/examples/helm-deployment/skaffold.yaml
+++ b/examples/helm-deployment/skaffold.yaml
@@ -12,5 +12,7 @@ deploy:
     releases:
     - name: skaffold-helm
       chartPath: examples/helm-deployment/skaffold-helm
+      namespace: skaffold
+      valuesFilePath: helm-skaffold-values.yaml
       values:
         image: skaffold-helm

--- a/pkg/skaffold/config/config.go
+++ b/pkg/skaffold/config/config.go
@@ -90,9 +90,11 @@ type HelmDeploy struct {
 }
 
 type HelmRelease struct {
-	Name      string            `yaml:"name"`
-	ChartPath string            `yaml:"chartPath"`
-	Values    map[string]string `yaml:"values"`
+	Name           string            `yaml:"name"`
+	ChartPath      string            `yaml:"chartPath"`
+	ValuesFilePath string            `yaml:"valuesFilePath"`
+	Values         map[string]string `yaml:"values"`
+	Namespace      string            `yaml:"namespace"`
 }
 
 // Artifact represents items that need should be built, along with the context in which

--- a/pkg/skaffold/deploy/helm.go
+++ b/pkg/skaffold/deploy/helm.go
@@ -80,6 +80,14 @@ func deployRelease(out io.Writer, r config.HelmRelease, b *build.BuildResult) er
 		args = []string{"upgrade", r.Name, r.ChartPath}
 	}
 
+	if r.Namespace != "" {
+		args = append(args, "--namespace", r.Namespace)
+	}
+
+	if r.ValuesFilePath != "" {
+		args = append(args, "-f", r.ValuesFilePath)
+	}
+
 	args = append(args, setOpts...)
 	stdout, stderr, err = util.RunCommand(exec.Command("helm", args...), nil)
 	if err != nil {


### PR DESCRIPTION
Hi,

Small PR for the helm deployer. It allows to specify a values file (`-f` flag) and a namespace (`--namespace`).

Example:
```
deploy:
  helm:
    releases:
    - name: skaffold-helm
      chartPath: examples/helm-deployment/skaffold-helm
      namespace: skaffold
      valuesFilePath: helm-skaffold-values.yaml
      values:
        image: skaffold-helm
```