### PR TITLE
Fixed Kubernetes context for build and deploy

### DIFF
--- a/pkg/skaffold/build/local_test.go
+++ b/pkg/skaffold/build/local_test.go
@@ -20,12 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"testing"
-
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/config"
@@ -268,21 +263,11 @@ func TestNewLocalBuilderError(t *testing.T) {
 				Workspace: ".",
 			},
 		},
-	})
+	}, "")
 	testutil.CheckError(t, true, err)
 }
 
 func TestNewLocalBuilderMinikubeContext(t *testing.T) {
-	tmpDir := os.TempDir()
-	kubeConfig := filepath.Join(tmpDir, "config")
-	defer os.Remove(kubeConfig)
-	if err := clientcmd.WriteToFile(api.Config{
-		CurrentContext: "minikube",
-	}, kubeConfig); err != nil {
-		t.Fatalf("writing temp kubeconfig")
-	}
-	unsetEnvs := testutil.SetEnvs(t, map[string]string{"KUBECONFIG": kubeConfig})
-	defer unsetEnvs(t)
 	_, err := NewLocalBuilder(&config.BuildConfig{
 		Artifacts: []*config.Artifact{
 			{
@@ -293,7 +278,7 @@ func TestNewLocalBuilderMinikubeContext(t *testing.T) {
 		BuildType: config.BuildType{
 			LocalBuild: &config.LocalBuild{},
 		},
-	})
+	}, "minikube")
 	if err != nil {
 		t.Errorf("New local builder: %s", err)
 	}

--- a/pkg/skaffold/deploy/kubectl_test.go
+++ b/pkg/skaffold/deploy/kubectl_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/spf13/afero"
 )
 
+const testKubeContext = "kubecontext"
+
 const deploymentYAML = `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -185,12 +187,10 @@ func TestKubectlRun(t *testing.T) {
 				util.DefaultExecCommand = test.command
 				defer util.ResetDefaultExecCommand()
 			}
-			k, err := NewKubectlDeployer(test.cfg)
-			if err != nil {
-				t.Errorf("Error getting kubectl deployer: %s", err)
-				return
-			}
+
+			k := NewKubectlDeployer(test.cfg, testKubeContext)
 			res, err := k.Run(&bytes.Buffer{}, test.b)
+
 			testutil.CheckErrorAndDeepEqual(t, test.shouldErr, err, test.expected, res)
 		})
 


### PR DESCRIPTION
Memoize the context and pass it to every kubectl and helm command.
Fixes #165

I didn't want to introduce a SkaffoldSession that would hold that kind of information
because right now there's only the kubecontext. WDYT?