### PR TITLE
[WIP] Validate image ID in stream logs, don't display logs during build and deploy

### DIFF
--- a/examples/getting-started/main.go
+++ b/examples/getting-started/main.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 	for {
-		fmt.Println("Hello world!")
+		fmt.Println("Hellooo world!")
 		time.Sleep(time.Second * 1)
 	}
 }

--- a/examples/getting-started/main.go
+++ b/examples/getting-started/main.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 	for {
-		fmt.Println("Hellooo world!")
+		fmt.Println("Hello jerry...!")
 		time.Sleep(time.Second * 1)
 	}
 }

--- a/examples/getting-started/main.go
+++ b/examples/getting-started/main.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 	for {
-		fmt.Println("Hello jerry...!")
+		fmt.Println("Hello world!")
 		time.Sleep(time.Second * 1)
 	}
 }

--- a/pkg/skaffold/build/build.go
+++ b/pkg/skaffold/build/build.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/config"
+	digest "github.com/opencontainers/go-digest"
 
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/build/tag"
 )
@@ -34,6 +35,7 @@ type Build struct {
 	ImageName string
 	Tag       string
 	Artifact  *config.Artifact // The artifact used in the build.
+	Digest    digest.Digest
 }
 
 // Builder is an interface to the Build API of Skaffold.

--- a/pkg/skaffold/build/container_builder.go
+++ b/pkg/skaffold/build/container_builder.go
@@ -35,6 +35,7 @@ import (
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/util"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -201,6 +202,7 @@ watch:
 		ImageName: artifact.ImageName,
 		Tag:       tag,
 		Artifact:  artifact,
+		Digest:    digest.FromString(imageID),
 	}, nil
 }
 

--- a/pkg/skaffold/build/container_builder.go
+++ b/pkg/skaffold/build/container_builder.go
@@ -198,11 +198,15 @@ watch:
 	logrus.Infof("Deleted object %s", buildObject)
 	tag := fmt.Sprintf("%s@%s", artifact.ImageName, imageID)
 	logrus.Infof("Image built at %s", tag)
+	digest, err := digest.Parse(imageID)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting digest")
+	}
 	return &Build{
 		ImageName: artifact.ImageName,
 		Tag:       tag,
 		Artifact:  artifact,
-		Digest:    digest.FromString(imageID),
+		Digest:    digest,
 	}, nil
 }
 

--- a/pkg/skaffold/build/local.go
+++ b/pkg/skaffold/build/local.go
@@ -129,6 +129,7 @@ func (l *LocalBuilder) Run(out io.Writer, tagger tag.Tagger, artifacts []*config
 			ImageName: artifact.ImageName,
 			Tag:       tag,
 			Artifact:  artifact,
+			Digest:    digest,
 		})
 	}
 

--- a/pkg/skaffold/build/tag/sha256.go
+++ b/pkg/skaffold/build/tag/sha256.go
@@ -18,7 +18,8 @@ package tag
 
 import (
 	"fmt"
-	"strings"
+
+	"github.com/pkg/errors"
 )
 
 // ChecksumTagger tags an image by the sha256 of the image tarball
@@ -32,10 +33,8 @@ func (c *ChecksumTagger) GenerateFullyQualifiedImageName(opts *TagOptions) (stri
 	if opts == nil {
 		return "", fmt.Errorf("Tag options not provided")
 	}
-	digestSplit := strings.Split(opts.Digest, ":")
-	if len(digestSplit) != 2 {
-		return "", fmt.Errorf("Digest wrong format: %s, expected sha256:<checksum>", digestSplit)
+	if err := opts.Digest.Validate(); err != nil {
+		return "", errors.Wrap(err, "validating digest")
 	}
-	checksum := digestSplit[1]
-	return fmt.Sprintf("%s:%s", opts.ImageName, checksum), nil
+	return fmt.Sprintf("%s:%s", opts.ImageName, opts.Digest.Encoded()), nil
 }

--- a/pkg/skaffold/build/tag/tag.go
+++ b/pkg/skaffold/build/tag/tag.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package tag
 
+import digest "github.com/opencontainers/go-digest"
+
 // Tagger is an interface for tag strategies to be implemented against
 type Tagger interface {
 	GenerateFullyQualifiedImageName(tagOpts *TagOptions) (string, error)
@@ -23,5 +25,5 @@ type Tagger interface {
 
 type TagOptions struct {
 	ImageName string
-	Digest    string
+	Digest    digest.Digest
 }

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -112,7 +112,7 @@ func Digest(cli client.ImageAPIClient, ref string) (digest.Digest, error) {
 	for _, image := range imageList {
 		for _, tag := range image.RepoTags {
 			if tag == refLatest {
-				return digest.FromString(image.ID), nil
+				return digest.Parse(image.ID)
 			}
 		}
 	}

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -30,6 +30,7 @@ import (
 	"github.com/moby/moby/pkg/jsonmessage"
 	"github.com/moby/moby/pkg/streamformatter"
 	"github.com/moby/moby/pkg/term"
+	digest "github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -98,7 +99,7 @@ func RunPush(cli client.ImageAPIClient, ref string, out io.Writer) error {
 // Digest returns the image digest for a corresponding reference.
 // The digest is of the form
 // sha256:<image_id>
-func Digest(cli client.ImageAPIClient, ref string) (string, error) {
+func Digest(cli client.ImageAPIClient, ref string) (digest.Digest, error) {
 	refLatest := fmt.Sprintf("%s:latest", ref)
 	args := filters.KeyValuePair{Key: "reference", Value: refLatest}
 	filters := filters.NewArgs(args)
@@ -111,7 +112,7 @@ func Digest(cli client.ImageAPIClient, ref string) (string, error) {
 	for _, image := range imageList {
 		for _, tag := range image.RepoTags {
 			if tag == refLatest {
-				return image.ID, nil
+				return digest.FromString(image.ID), nil
 			}
 		}
 	}

--- a/pkg/skaffold/kubernetes/log.go
+++ b/pkg/skaffold/kubernetes/log.go
@@ -91,11 +91,12 @@ func StreamLogs(out io.Writer, client corev1.CoreV1Interface, image string, dige
 
 func streamRequest(out io.Writer, header string, rc io.Reader) error {
 	r := bufio.NewReader(rc)
+loop:
 	for {
 		// Read up to newline
 		line, err := r.ReadBytes('\n')
 		if err == io.EOF {
-			break
+			break loop
 		}
 		if err != nil {
 			return errors.Wrap(err, "reading bytes from log stream")

--- a/pkg/skaffold/kubernetes/log.go
+++ b/pkg/skaffold/kubernetes/log.go
@@ -31,7 +31,7 @@ import (
 	restclient "k8s.io/client-go/rest"
 )
 
-const streamRetryDelay = 1 * time.Second
+const streamRetryDelay = 250 * time.Millisecond
 
 // TODO(@r2d4): Figure out how to mock this out. fake.NewSimpleClient
 // won't mock out restclient.Request and will just return a nil stream.
@@ -39,17 +39,22 @@ var getStream = func(r *restclient.Request) (io.ReadCloser, error) {
 	return r.Stream()
 }
 
-func StreamLogsRetry(out io.Writer, client corev1.CoreV1Interface, image string, digest digest.Digest, retry int) {
-	for i := 0; i < retry; i++ {
-		if err := StreamLogs(out, client, image, digest); err != nil {
-			logrus.Infof("Error getting logs %s", err)
+func StreamLogsRetry(out io.Writer, client corev1.CoreV1Interface, image string, digest digest.Digest, cancel chan struct{}) {
+	for {
+		select {
+		case <-cancel:
+			return
+		default:
+			if err := StreamLogs(out, client, image, digest, cancel); err != nil {
+				logrus.Infof("Error getting logs %s", err)
+			}
 		}
 		time.Sleep(streamRetryDelay)
 	}
 }
 
 // nolint: interfacer
-func StreamLogs(out io.Writer, client corev1.CoreV1Interface, image string, digest digest.Digest) error {
+func StreamLogs(out io.Writer, client corev1.CoreV1Interface, image string, digest digest.Digest, cancel chan struct{}) error {
 	pods, err := client.Pods("").List(meta_v1.ListOptions{
 		IncludeUninitialized: true,
 	})
@@ -77,7 +82,7 @@ func StreamLogs(out io.Writer, client corev1.CoreV1Interface, image string, dige
 				}
 				defer rc.Close()
 				header := fmt.Sprintf("[%s %s]", p.Name, c.Name)
-				if err := streamRequest(out, header, rc); err != nil {
+				if err := streamRequest(out, header, rc, cancel); err != nil {
 					return errors.Wrap(err, "streaming request")
 				}
 
@@ -89,23 +94,27 @@ func StreamLogs(out io.Writer, client corev1.CoreV1Interface, image string, dige
 	return fmt.Errorf("Image %s not found", image)
 }
 
-func streamRequest(out io.Writer, header string, rc io.Reader) error {
+func streamRequest(out io.Writer, header string, rc io.Reader, cancel chan struct{}) error {
 	r := bufio.NewReader(rc)
-loop:
 	for {
-		// Read up to newline
-		line, err := r.ReadBytes('\n')
-		if err == io.EOF {
-			break loop
-		}
-		if err != nil {
-			return errors.Wrap(err, "reading bytes from log stream")
-		}
-		msg := fmt.Sprintf("%s %s", header, line)
-		if _, err := out.Write([]byte(msg)); err != nil {
-			return errors.Wrap(err, "writing to out")
+		select {
+		case <-cancel:
+			logrus.Infof("%s Stream canceled", header)
+			return nil
+		default:
+			// Read up to newline
+			line, err := r.ReadBytes('\n')
+			if err == io.EOF {
+				logrus.Infof("%s exited", header)
+				return nil
+			}
+			if err != nil {
+				return errors.Wrap(err, "reading bytes from log stream")
+			}
+			msg := fmt.Sprintf("%s %s", header, line)
+			if _, err := out.Write([]byte(msg)); err != nil {
+				return errors.Wrap(err, "writing to out")
+			}
 		}
 	}
-	logrus.Infof("%s exited", header)
-	return nil
 }

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -149,6 +149,7 @@ func (r *SkaffoldRunner) dev() error {
 				go kubernetes.StreamLogsRetry(r.opts.Output, r.kubeclient.CoreV1(), b.Tag, b.Digest, 5)
 			}
 		}
+		fmt.Fprint(r.opts.Output, "Watching for changes...\n")
 		evt, err := r.Watch(r.config.Build.Artifacts, r.watchReady, r.cancel)
 		if err != nil {
 			return errors.Wrap(err, "running watch")

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -143,10 +143,11 @@ func (r *SkaffoldRunner) dev() error {
 		logrus.Warnf("run: %s", err)
 	}
 	for {
+		r.cancel = make(chan struct{})
 		if bRes != nil {
 			for _, b := range bRes.Builds {
 				b := b
-				go kubernetes.StreamLogsRetry(r.opts.Output, r.kubeclient.CoreV1(), b.Tag, b.Digest, 5)
+				go kubernetes.StreamLogsRetry(r.opts.Output, r.kubeclient.CoreV1(), b.Tag, b.Digest, r.cancel)
 			}
 		}
 		fmt.Fprint(r.opts.Output, "Watching for changes...\n")
@@ -157,6 +158,8 @@ func (r *SkaffoldRunner) dev() error {
 		if evt.EventType == watch.WatchStop {
 			return nil
 		}
+		// Close all watchers and log streamers
+		close(r.cancel)
 		bRes, _, err = r.run(evt.ChangedArtifacts)
 		if err != nil {
 			// In dev mode, we only warn on pipeline errors

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -145,8 +145,8 @@ func (r *SkaffoldRunner) dev() error {
 	for {
 		if bRes != nil {
 			for _, b := range bRes.Builds {
-				tag := b.Tag
-				go kubernetes.StreamLogsRetry(r.opts.Output, r.kubeclient.CoreV1(), tag, 5)
+				b := b
+				go kubernetes.StreamLogsRetry(r.opts.Output, r.kubeclient.CoreV1(), b.Tag, b.Digest, 5)
 			}
 		}
 		evt, err := r.Watch(r.config.Build.Artifacts, r.watchReady, r.cancel)


### PR DESCRIPTION
Fixes #166 

I ran into an interesting error when using `skaffold dev`.

The apiserver was returning "pod ready" even with the updated container tag while still running the old image. I'll have to investigate this upstream, but here are some sample logs from before this change

I've included some sample output below, but I was able to get around this by also verifying the digest of the running container inside the pod. 

Additionally, I've added a cancel channel to the streaming logs so that they aren't streamed during build and deploy.

I've left the logs outside code brackets so that I can bold the relevant fields. 

**rebuild image**

(*v1.Pod)(0xc42094aa80)(&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:getting-started,GenerateName:,Namespace:default,SelfLink:/api/v1/namespaces/default/pods/getting-started,UID:890e1e32-2496-11e8-9915-08002794bea8,ResourceVersion:971545,Generation:0,CreationTimestamp:2018-03-10 11:09:19 -0800 PST,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{},Annotations:map[string]string{kubectl.kubernetes.io/last-applied-configuration: {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{},"name":"getting-started","namespace":"default"},"spec":{"containers":[{**"image":"gcr.io/k8s-skaffold/skaffold-example:5ad66aadeeabac018a7116cd8d61d27318f2177b0c8d99fcc8d1cf7f6e16ecb2","name":"getting-started"**}]}}
,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-t5tv7 {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-t5tv7,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{getting-started gcr.io/k8s-skaffold/skaffold-example:5ad66aadeeabac018a7116cd8d61d27318f2177b0c8d99fcc8d1cf7f6e16ecb2 [] []  [] [] [] {map[] map[]} [{default-token-t5tv7 true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:minikube,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc42068e0b0} {node.kubernetes.io/unreachable Exists  NoExecute 0xc42068e0d0}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,},**Status:PodStatus{Phase:Running**,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-03-10 11:09:19 -0800 PST  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-03-10 11:09:21 -0800 PST  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-03-10 11:09:19 -0800 PST  }],Message:,Reason:,HostIP:10.0.2.15,PodIP:172.17.0.5,StartTime:2018-03-10 11:09:19 -0800 PST,ContainerStatuses:[{getting-started {nil ContainerStateRunning{StartedAt:2018-03-10 13:46:58 -0800 PST,} nil} {nil nil &ContainerStateTerminated{ExitCode:2,Signal:0,Reason:Error,Message:,StartedAt:2018-03-10 13:46:44 -0800 PST,FinishedAt:2018-03-10 13:46:58 -0800 PST,ContainerID:docker://d652609f69578c4664e9b3d5378db39342b8a0c47cc50ecb491153a92d9571cf,}} true 44 5e91bc788ef46f4173976039947155d5:latest **docker://sha256:9ceea103e0c6b8626774ff34704f96a8fb609dca028370e172409ff9f263aee8** docker://51ac8f7b29a0c2c2a62614a8eba6eabbc1f317a8532a63821256e6c2a0d981e8}],QOSClass:BestEffort,InitContainerStatuses:[],},})
pod ready for image gcr.io/k8s-skaffold/skaffold-example:5ad66aadeeabac018a7116cd8d61d27318f2177b0c8d99fcc8d1cf7f6e16ecb2


**EOF sent for previous image**
**Send new k8s API Pod request**


image is now gcr.io/k8s-skaffold/skaffold-example:5ad66aadeeabac018a7116cd8d61d27318f2177b0c8d99fcc8d1cf7f6e16ecb2
started at 2018-03-10 11:09:19 -0800 PST current time:  2018-03-10 13:49:09.640232844 -0800 PST m=+16.957619747
(*v1.Pod)(0xc420a56380)(&Pod{ObjectMeta:k8s_io_apimachinery_pkg_apis_meta_v1.ObjectMeta{Name:getting-started,GenerateName:,Namespace:default,SelfLink:/api/v1/namespaces/default/pods/getting-started,UID:890e1e32-2496-11e8-9915-08002794bea8,ResourceVersion:971547,Generation:0,CreationTimestamp:2018-03-10 11:09:19 -0800 PST,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{},Annotations:map[string]string{kubectl.kubernetes.io/last-applied-configuration: {"apiVersion":"v1","kind":"Pod","metadata":{"annotations":{},"name":"getting-started","namespace":"default"},"spec":{**"containers":[{"image":"gcr.io/k8s-skaffold/skaffold-example:5ad66aadeeabac018a7116cd8d61d27318f2177b0c8d99fcc8d1cf7f6e16ecb2","name":"getting-started"}**]}}
,},OwnerReferences:[],Finalizers:[],ClusterName:,Initializers:nil,},Spec:PodSpec{Volumes:[{default-token-t5tv7 {nil nil nil nil nil SecretVolumeSource{SecretName:default-token-t5tv7,Items:[],DefaultMode:*420,Optional:nil,} nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil nil}}],Containers:[{getting-started gcr.io/k8s-skaffold/skaffold-example:5ad66aadeeabac018a7116cd8d61d27318f2177b0c8d99fcc8d1cf7f6e16ecb2 [] []  [] [] [] {map[] map[]} [{default-token-t5tv7 true /var/run/secrets/kubernetes.io/serviceaccount  <nil>}] [] nil nil nil /dev/termination-log File IfNotPresent nil false false false}],RestartPolicy:Always,TerminationGracePeriodSeconds:*30,ActiveDeadlineSeconds:nil,DNSPolicy:ClusterFirst,NodeSelector:map[string]string{},ServiceAccountName:default,DeprecatedServiceAccount:default,NodeName:minikube,HostNetwork:false,HostPID:false,HostIPC:false,SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,},ImagePullSecrets:[],Hostname:,Subdomain:,Affinity:nil,SchedulerName:default-scheduler,InitContainers:[],AutomountServiceAccountToken:nil,Tolerations:[{node.kubernetes.io/not-ready Exists  NoExecute 0xc420b1a8f0} {node.kubernetes.io/unreachable Exists  NoExecute 0xc420b1a910}],HostAliases:[],PriorityClassName:,Priority:nil,DNSConfig:nil,},**Status:PodStatus{Phase:Running**,Conditions:[{Initialized True 0001-01-01 00:00:00 +0000 UTC 2018-03-10 11:09:19 -0800 PST  } {Ready True 0001-01-01 00:00:00 +0000 UTC 2018-03-10 11:09:21 -0800 PST  } {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2018-03-10 11:09:19 -0800 PST  }],Message:,Reason:,HostIP:10.0.2.15,PodIP:172.17.0.5,StartTime:2018-03-10 11:09:19 -0800 PST,ContainerStatuses:[{getting-started {nil ContainerStateRunning{StartedAt:2018-03-10 13:49:04 -0800 PST,} nil} {nil nil &ContainerStateTerminated{ExitCode:2,Signal:0,Reason:Error,Message:,StartedAt:2018-03-10 13:46:58 -0800 PST,FinishedAt:2018-03-10 13:49:04 -0800 PST,ContainerID:docker://51ac8f7b29a0c2c2a62614a8eba6eabbc1f317a8532a63821256e6c2a0d981e8,}} true 45 8582dfc79595d2cbe53ec050bed9e616:latest **docker://sha256:5ad66aadeeabac018a7116cd8d61d27318f2177b0c8d99fcc8d1cf7f6e16ecb2** docker://0375b9e38be5e395b128202d79b111619683ca590d2276bd926dd96ab6a222a6}],QOSClass:BestEffort,InitContainerStatuses:[],},})


