### PR TITLE
local: refactor docker client getting

### DIFF
--- a/pkg/skaffold/docker/client_test.go
+++ b/pkg/skaffold/docker/client_test.go
@@ -49,7 +49,7 @@ func TestNewEnvClient(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			unsetEnvs := testutil.SetEnvs(t, test.envs)
-			_, _, err := NewImageAPIClient()
+			_, err := NewImageAPIClient()
 			testutil.CheckError(t, test.shouldErr, err)
 			unsetEnvs(t)
 		})
@@ -114,7 +114,7 @@ DOCKER_API_VERSION=1.23`, "", nil),
 			util.DefaultExecCommand = test.cmd
 			defer util.ResetDefaultExecCommand()
 
-			_, _, err := NewMinikubeImageAPIClient()
+			_, err := NewMinikubeImageAPIClient()
 			testutil.CheckError(t, test.shouldErr, err)
 		})
 	}

--- a/testutil/fake_image_api.go
+++ b/testutil/fake_image_api.go
@@ -121,30 +121,4 @@ func (f *FakeImageAPIClient) ImagePush(_ context.Context, _ string, _ types.Imag
 	return f.opts.ReturnBody, err
 }
 
-func NewFakeImageAPIClientCloser() (client.ImageAPIClient, io.Closer, error) {
-	fakeAPI := NewFakeImageAPIClient(map[string]string{}, &FakeImageAPIOptions{})
-	return fakeAPI, fakeAPI, nil
-}
-
-func NewFakeImageAPIClientCloserBuildError() (client.ImageAPIClient, io.Closer, error) {
-	fakeAPI := NewFakeImageAPIClient(map[string]string{}, &FakeImageAPIOptions{
-		ErrImageBuild: true,
-	})
-	return fakeAPI, fakeAPI, nil
-}
-
-func NewFakeImageAPIClientCloserTagError() (client.ImageAPIClient, io.Closer, error) {
-	fakeAPI := NewFakeImageAPIClient(map[string]string{}, &FakeImageAPIOptions{
-		ErrImageTag: true,
-	})
-	return fakeAPI, fakeAPI, nil
-}
-
-func NewFakeImageAPIClientCloserListError() (client.ImageAPIClient, io.Closer, error) {
-	fakeAPI := NewFakeImageAPIClient(map[string]string{}, &FakeImageAPIOptions{
-		ErrImageList: true,
-	})
-	return fakeAPI, fakeAPI, nil
-}
-
 func (f *FakeImageAPIClient) Close() error { return nil }


### PR DESCRIPTION
It was a questionable construction to begin with and this cleans it up a bit.

My future thought here is to use the New{LocalBuilder, etc.} functions to do all the preparation for the run cycles. Since these are only called once, they should do things like verify their connections to docker, the cluster, and whatever else they need. Moving the actual api setup out of the run function will help us catch issues before we enter run.