### PR TITLE
config: use v1alpha1 as config is subject to change

### DIFF
--- a/examples/getting-started/skaffold-gcb.yaml
+++ b/examples/getting-started/skaffold-gcb.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1
+apiVersion: skaffold/v1alpha1
 kind: Config
 build:
   artifacts:

--- a/examples/getting-started/skaffold.yaml
+++ b/examples/getting-started/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1
+apiVersion: skaffold/v1alpha1
 kind: Config
 build:
   # tagPolicy determines how skaffold is going to tag your image

--- a/examples/helm-deployment/skaffold.yaml
+++ b/examples/helm-deployment/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1
+apiVersion: skaffold/v1alpha1
 kind: Config
 build:
   tagPolicy: sha256

--- a/examples/no-manifest/skaffold.yaml
+++ b/examples/no-manifest/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1
+apiVersion: skaffold/v1alpha1
 kind: Config
 build:
   artifacts:

--- a/pkg/skaffold/config/config_test.go
+++ b/pkg/skaffold/config/config_test.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	rawConfigA = `
-apiVersion: skaffold/v1
+apiVersion: skaffold/v1alpha1
 kind: Config
 build:
   artifacts:
@@ -40,7 +40,7 @@ deploy:
 )
 
 var configA = &SkaffoldConfig{
-	APIVersion: "skaffold/v1",
+	APIVersion: "skaffold/v1alpha1",
 	Kind:       "Config",
 	Build: BuildConfig{
 		TagPolicy: constants.TagStrategySha256,

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1
+apiVersion: skaffold/v1alpha1
 kind: Config
 build:
   artifacts:


### PR DESCRIPTION
To be consistent with kubernetes versioning policies.