### PR TITLE
fix:(env vars) allow environment variables to be used for images

### DIFF
--- a/pkg/skaffold/build/local.go
+++ b/pkg/skaffold/build/local.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/config"
@@ -114,8 +115,9 @@ func (l *LocalBuilder) Build(out io.Writer, tagger tag.Tagger, artifacts []*conf
 		if digest == "" {
 			return nil, fmt.Errorf("digest not found")
 		}
+		imageName := os.ExpandEnv(artifact.ImageName)
 		tag, err := tagger.GenerateFullyQualifiedImageName(&tag.TagOptions{
-			ImageName: artifact.ImageName,
+			ImageName: imageName,
 			Digest:    digest,
 		})
 		if err != nil {
@@ -133,7 +135,7 @@ func (l *LocalBuilder) Build(out io.Writer, tagger tag.Tagger, artifacts []*conf
 			}
 		}
 		res.Builds = append(res.Builds, Build{
-			ImageName: artifact.ImageName,
+			ImageName: imageName,
 			Tag:       tag,
 			Artifact:  artifact,
 		})


### PR DESCRIPTION
so we can refer to docker registries via environment variables, e.g. if the docker registry is running inside a kubernetes cluster so that kubernetes service discovery does not work (as the local docker daemon is not running inside k8s)

fixes #184