### PR TITLE
log: reset creation time on dev cycle

### DIFF
--- a/pkg/skaffold/kubernetes/log.go
+++ b/pkg/skaffold/kubernetes/log.go
@@ -88,6 +88,10 @@ func (a *LogAggregator) StreamLogs(client corev1.CoreV1Interface, image string) 
 	}
 }
 
+func (a *LogAggregator) SetCreationTime(t time.Time) {
+	a.creationTime = t
+}
+
 // nolint: interfacer
 func (a *LogAggregator) streamLogs(client corev1.CoreV1Interface, image string) error {
 	pods, err := client.Pods("").List(meta_v1.ListOptions{

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -145,12 +145,12 @@ func (r *SkaffoldRunner) dev(artifacts []*config.Artifact) error {
 	onChange := func(artifacts []*config.Artifact) {
 		logger.Mute()
 
+		logger.SetCreationTime(time.Now())
 		bRes, _, err := r.run(artifacts)
 		if err != nil {
 			// In dev mode, we only warn on pipeline errors
 			logrus.Warnf("run: %s", err)
 		}
-
 		logger.Unmute()
 
 		if bRes != nil {


### PR DESCRIPTION
if we don't reset the starting time on the logger, if we grab the previous container (kubernetes hasn't update it yet) we'll duplicate all the logs since the creation of that container.

before:

```
[getting-started getting-started] 08:46:06.176868
[getting-started getting-started] 08:46:07.177052
[getting-started getting-started] 08:46:08.177785
[getting-started getting-started] 08:46:09.178169
[getting-started getting-started] 08:46:10.178789
[getting-started getting-started] 08:46:11.179309

build and deploy

[getting-started getting-started] 08:46:06.176868
[getting-started getting-started] 08:46:07.177052
[getting-started getting-started] 08:46:08.177785
[getting-started getting-started] 08:46:09.178169
[getting-started getting-started] 08:46:10.178789
[getting-started getting-started] 08:46:11.179309
[getting-started getting-started] 08:46:12.179784
[getting-started getting-started] 08:46:12.179784
```

after:


```
[getting-started getting-started] 08:45:07.787807
[getting-started getting-started] 08:45:07.787807

build and deploy...

[getting-started getting-started] 08:45:08.790977
[getting-started getting-started] 08:45:09.792990
[getting-started getting-started] 08:45:09.792990
```
