### PR TITLE
Support private registries at build time

### DIFF
--- a/pkg/skaffold/docker/auth.go
+++ b/pkg/skaffold/docker/auth.go
@@ -74,7 +74,10 @@ func (credsHelper) GetAllAuthConfigs() (map[string]types.AuthConfig, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "docker config")
 	}
-	return cf.GetAllCredentials()
+
+	// TODO(dgageot): this is really slow because it has to run all the credential helpers.
+	// return cf.GetAllCredentials()
+	return cf.GetCredentialsStore("").GetAll()
 }
 
 func encodedRegistryAuth(a AuthConfigHelper, image string) (string, error) {

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -46,14 +46,16 @@ type BuildOptions struct {
 // RunBuild performs a docker build and returns nothing
 func RunBuild(cli client.ImageAPIClient, opts *BuildOptions) error {
 	logrus.Debugf("Running docker build: context: %s, dockerfile: %s", opts.ContextDir, opts.Dockerfile)
+	authConfigs, err := DefaultAuthHelper.GetAllAuthConfigs()
+	if err != nil {
+		return errors.Wrap(err, "read auth configs")
+	}
+
 	imageBuildOpts := types.ImageBuildOptions{
-		Tags:       []string{opts.ImageName},
-		Dockerfile: opts.Dockerfile,
-		BuildArgs:  opts.BuildArgs,
-		// TODO(@r2d4): Currently works, but is really slow,
-		// figure out how to get all private registry tokens in faster way
-		//
-		// AuthConfigs: auth.getAllAuthConfigs(),
+		Tags:        []string{opts.ImageName},
+		Dockerfile:  opts.Dockerfile,
+		BuildArgs:   opts.BuildArgs,
+		AuthConfigs: authConfigs,
 	}
 
 	buildCtx, err := archive.TarWithOptions(opts.ContextDir, &archive.TarOptions{


### PR DESCRIPTION
Does support private registries with auth token but does not support credential helpers yet because it's VERY slow.

Related to #239

Signed-off-by: David Gageot <david@gageot.net>