### PR TITLE
fix:(env vars) allow environment variables to be used in the yaml

### DIFF
--- a/pkg/skaffold/config/config.go
+++ b/pkg/skaffold/config/config.go
@@ -19,8 +19,9 @@ package config
 import (
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/constants"
 
-	yaml "gopkg.in/yaml.v2"
 	"os"
+
+	yaml "gopkg.in/yaml.v2"
 )
 
 // SkaffoldConfig is the top level config object

--- a/pkg/skaffold/config/config.go
+++ b/pkg/skaffold/config/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/constants"
 
 	yaml "gopkg.in/yaml.v2"
+	"os"
 )
 
 // SkaffoldConfig is the top level config object
@@ -125,7 +126,9 @@ var DefaultRunSkaffoldConfig = &SkaffoldConfig{
 // The default config argument provides default values for the config,
 // which can be overridden if present in the config file.
 func Parse(config []byte, defaultConfig *SkaffoldConfig) (*SkaffoldConfig, error) {
-	if err := yaml.Unmarshal(config, defaultConfig); err != nil {
+	// lets expand any environment variable expressions in the config
+	expanded := os.ExpandEnv(string(config))
+	if err := yaml.Unmarshal([]byte(expanded), defaultConfig); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
so we can refer to docker registries via environment variables, e.g. if the docker registry is running inside a kubernetes cluster so that kubernetes service discovery does not work (as the local docker daemon is not running inside k8s)

this approach lets us use environment variable expressions anywhere in the YAML

fixes #184