### PR TITLE
deploy: fix cloudbuild-release

### DIFF
--- a/deploy/cloudbuild-release.yaml
+++ b/deploy/cloudbuild-release.yaml
@@ -1,7 +1,7 @@
 steps:
 # Build the container that will do the go build.
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '--target', 'build', '-t', 'builder', '-f', 'deploy/skaffold/Dockerfile', '.']
+    args: ['build', '-t', 'builder', '-f', 'deploy/skaffold/Dockerfile', '.']
 # Do the go build.
   - name: 'builder'
     args: ['make', 'cross']


### PR DESCRIPTION
This is no longer an odd multistage dockerfile, so just a normal build should work. I did this manually last night.