### PR TITLE
Non-docker builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 out/
+examples/bazel/bazel-*

--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -21,6 +21,7 @@ build:
 
     # workspace is the path to your dockerfile context
     workspace: ../examples/getting-started
+    docker: {}
 
   # This next section is where you'll put your specific builder configuration.
   # Here, we're using a local builder, which simply builds using the host docker

--- a/examples/bazel/BUILD
+++ b/examples/bazel/BUILD
@@ -1,0 +1,6 @@
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+
+go_image(
+    name = "skaffold_example",
+    srcs = ["main.go"],
+)

--- a/examples/bazel/BUILD
+++ b/examples/bazel/BUILD
@@ -3,4 +3,7 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 go_image(
     name = "skaffold_example",
     srcs = ["main.go"],
+    goos = "linux",
+    goarch = "amd64",
+    static = "on",
 )

--- a/examples/bazel/WORKSPACE
+++ b/examples/bazel/WORKSPACE
@@ -1,0 +1,25 @@
+workspace(name = "skaffold")
+
+git_repository(
+    name = "io_bazel_rules_docker",
+    remote = "https://github.com/bazelbuild/rules_docker.git",
+    tag = "v0.4.0",
+)
+
+http_archive(
+    name = "io_bazel_rules_go",
+    sha256 = "4d8d6244320dd751590f9100cf39fd7a4b75cd901e1f3ffdfd6f048328883695",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.9.0/rules_go-0.9.0.tar.gz",
+)
+
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+
+go_rules_dependencies()
+go_register_toolchains()
+
+load(
+    "@io_bazel_rules_docker//go:image.bzl",
+    _go_image_repos = "repositories",
+)
+
+_go_image_repos()

--- a/examples/bazel/WORKSPACE
+++ b/examples/bazel/WORKSPACE
@@ -8,14 +8,16 @@ git_repository(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "4d8d6244320dd751590f9100cf39fd7a4b75cd901e1f3ffdfd6f048328883695",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.9.0/rules_go-0.9.0.tar.gz",
+    sha256 = "feba3278c13cde8d67e341a837f69a029f698d7a27ddbb2a202be7a10b22142a",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.10.3/rules_go-0.10.3.tar.gz",
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
 
 go_rules_dependencies()
-go_register_toolchains()
+go_register_toolchains(
+    go_version = "1.10.1",
+)
 
 load(
     "@io_bazel_rules_docker//go:image.bzl",

--- a/examples/bazel/main.go
+++ b/examples/bazel/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello bazel!!!!")
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/examples/bazel/skaffold.yaml
+++ b/examples/bazel/skaffold.yaml
@@ -4,14 +4,10 @@ build:
   artifacts:
   - imageName: gcr.io/k8s-skaffold/skaffold-example
     workspace: .
-    docker: {}
+    bazel:
+      target: //:skaffold_example.tar
   local: {}
 deploy:
   kubectl:
     manifests:
-      - k8s-*
-profiles:
-  - name: gcb
-    build:
-      googleCloudBuild:
-        projectId: k8s-skaffold
+      - ../getting-started/k8s-*

--- a/examples/getting-started/skaffold-gcb.yaml
+++ b/examples/getting-started/skaffold-gcb.yaml
@@ -1,0 +1,13 @@
+apiVersion: skaffold/v1alpha2
+kind: Config
+build:
+  artifacts:
+  - imageName: gcr.io/k8s-skaffold/skaffold-example
+    workspace: .
+    docker: {}
+  googleCloudBuild:
+    projectId: k8s-skaffold
+deploy:
+  kubectl:
+    manifests:
+    - k8s-*

--- a/examples/getting-started/skaffold.yaml
+++ b/examples/getting-started/skaffold.yaml
@@ -4,7 +4,6 @@ build:
   artifacts:
   - imageName: gcr.io/k8s-skaffold/skaffold-example
     workspace: .
-    docker: {}
   local: {}
 deploy:
   kubectl:

--- a/examples/getting-started/skaffold.yaml
+++ b/examples/getting-started/skaffold.yaml
@@ -3,7 +3,8 @@ kind: Config
 build:
   artifacts:
   - imageName: gcr.io/k8s-skaffold/skaffold-example
-    workspace: .
+    docker:
+      workspace: .
   local: {}
 deploy:
   kubectl:

--- a/examples/helm-deployment/skaffold.yaml
+++ b/examples/helm-deployment/skaffold.yaml
@@ -6,6 +6,7 @@ build:
   artifacts:
   - imageName: skaffold-helm
     workspace: .
+    docker: {}
   local: {}
 deploy:
   helm:

--- a/examples/microservices/skaffold.yaml
+++ b/examples/microservices/skaffold.yaml
@@ -4,8 +4,10 @@ build:
   artifacts:
   - imageName: gcr.io/k8s-skaffold/leeroy-web
     workspace: ./leeroy-web/
+    docker: {}
   - imageName: gcr.io/k8s-skaffold/leeroy-app
     workspace: ./leeroy-app/
+    docker: {}
   local: {}
 deploy:
   kubectl:

--- a/examples/no-manifest/skaffold.yaml
+++ b/examples/no-manifest/skaffold.yaml
@@ -4,6 +4,7 @@ build:
   artifacts:
   - imageName: gcr.io/k8s-skaffold/skaffold-no-manifest-example
     workspace: .
+    docker: {}
   local: {}
 deploy:
   kubectl:

--- a/pkg/skaffold/bazel/bazel.go
+++ b/pkg/skaffold/bazel/bazel.go
@@ -1,4 +1,20 @@
-package build
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bazel
 
 import (
 	"fmt"
@@ -27,6 +43,9 @@ func (*BazelDependencyResolver) GetDependencies(a *config.Artifact) ([]string, e
 			continue
 		}
 		if strings.HasPrefix(l, "//external") {
+			continue
+		}
+		if l == "" {
 			continue
 		}
 		dep := strings.TrimPrefix(l, "//:")

--- a/pkg/skaffold/build/bazel.go
+++ b/pkg/skaffold/build/bazel.go
@@ -1,10 +1,36 @@
 package build
 
-import "github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/config"
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/config"
+	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/util"
+	"github.com/pkg/errors"
+)
 
 type BazelDependencyResolver struct{}
 
-// TODO(r2d4): implement
+const sourceQuery = "kind('source file', deps('%s'))"
+
 func (*BazelDependencyResolver) GetDependencies(a *config.Artifact) ([]string, error) {
-	return []string{}, nil
+	cmd := exec.Command("bazel", "query", fmt.Sprintf(sourceQuery, a.BazelArtifact.BuildTarget), "--noimplicit_deps", "--order_output=no")
+	stdout, stderr, err := util.RunCommand(cmd, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "stdout: %s stderr: %s", stdout, stderr)
+	}
+	labels := strings.Split(string(stdout), "\n")
+	var deps []string
+	for _, l := range labels {
+		if strings.HasPrefix(l, "@") {
+			continue
+		}
+		if strings.HasPrefix(l, "//external") {
+			continue
+		}
+		dep := strings.TrimPrefix(l, "//:")
+		deps = append(deps, dep)
+	}
+	return deps, nil
 }

--- a/pkg/skaffold/build/bazel.go
+++ b/pkg/skaffold/build/bazel.go
@@ -1,0 +1,10 @@
+package build
+
+import "github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/config"
+
+type BazelDependencyResolver struct{}
+
+// TODO(r2d4): implement
+func (*BazelDependencyResolver) GetDependencies(a *config.Artifact) ([]string, error) {
+	return []string{}, nil
+}

--- a/pkg/skaffold/build/container_builder.go
+++ b/pkg/skaffold/build/container_builder.go
@@ -120,7 +120,7 @@ func (cb *GoogleCloudBuilder) buildArtifact(ctx context.Context, out io.Writer, 
 	}
 
 	fmt.Fprintf(out, "Pushing code to gs://%s/%s\n", cbBucket, buildObject)
-	if err := cb.uploadTarToGCS(ctx, artifact.DockerArtifact.DockerfilePath, artifact.DockerArtifact.Workspace, cbBucket, buildObject); err != nil {
+	if err := cb.uploadTarToGCS(ctx, artifact.DockerArtifact.DockerfilePath, artifact.Workspace, cbBucket, buildObject); err != nil {
 		return nil, errors.Wrap(err, "uploading source tarball")
 	}
 	call := cbclient.Projects.Builds.Create(cb.GoogleCloudBuild.ProjectID, &cloudbuild.Build{

--- a/pkg/skaffold/build/container_builder.go
+++ b/pkg/skaffold/build/container_builder.go
@@ -105,8 +105,8 @@ func (cb *GoogleCloudBuilder) Build(ctx context.Context, out io.Writer, tagger t
 }
 
 func (cb *GoogleCloudBuilder) buildArtifact(ctx context.Context, out io.Writer, cbclient *cloudbuild.Service, c *cstorage.Client, artifact *config.Artifact) (*Build, error) {
-	if artifact.DockerArtifact.DockerfilePath == "" {
-		artifact.DockerArtifact.DockerfilePath = constants.DefaultDockerfilePath
+	if artifact.DockerArtifact == nil {
+		artifact.DockerArtifact = config.DefaultDockerArtifact
 	}
 	logrus.Infof("Building artifact: %+v", artifact)
 	cbBucket := fmt.Sprintf("%s%s", cb.GoogleCloudBuild.ProjectID, constants.GCSBucketSuffix)

--- a/pkg/skaffold/build/deps.go
+++ b/pkg/skaffold/build/deps.go
@@ -112,10 +112,11 @@ func pathsForArtifact(a *config.Artifact) ([]string, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "getting dockerfile dependencies")
 	}
+	logrus.Infof("Source code dependencies %s: %s", a.ImageName, deps)
 	filteredDeps := []string{}
 	for _, dep := range deps {
 		//TODO(r2d4): what does the ignore workspace look like for bazel?
-		ignored, err := isIgnored(a.DockerArtifact.Workspace, dep)
+		ignored, err := isIgnored(a.Workspace, dep)
 		if err != nil {
 			return nil, errors.Wrapf(err, "calculating ignored files for artifact %s", a.ImageName)
 		}

--- a/pkg/skaffold/build/deps.go
+++ b/pkg/skaffold/build/deps.go
@@ -146,5 +146,8 @@ func GetDependenciesForArtifact(a *config.Artifact) ([]string, error) {
 	if a.BazelArtifact != nil {
 		return DefaultBazelDepResolver.GetDependencies(a)
 	}
-	return nil, errors.New("unknown artifact type")
+
+	logrus.Infof("No artifact type found for %+v, default to docker", a)
+	a.DockerArtifact = config.DefaultDockerArtifact
+	return DefaultDockerfileDepResolver.GetDependencies(a)
 }

--- a/pkg/skaffold/build/deps.go
+++ b/pkg/skaffold/build/deps.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/bazel"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/config"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/docker"
 	"github.com/pkg/errors"
@@ -128,13 +129,22 @@ func pathsForArtifact(a *config.Artifact) ([]string, error) {
 	return filteredDeps, nil
 }
 
+var (
+	DefaultDockerfileDepResolver DependencyResolver
+	DefaultBazelDepResolver      DependencyResolver
+)
+
+func init() {
+	DefaultDockerfileDepResolver = &docker.DockerfileDepResolver{}
+	DefaultBazelDepResolver = &bazel.BazelDependencyResolver{}
+}
+
 func GetDependenciesForArtifact(a *config.Artifact) ([]string, error) {
 	if a.DockerArtifact != nil {
-		return docker.DefaultDockerfileDepResolver.GetDependencies(a)
+		return DefaultDockerfileDepResolver.GetDependencies(a)
 	}
 	if a.BazelArtifact != nil {
-		b := &BazelDependencyResolver{}
-		return b.GetDependencies(a)
+		return DefaultBazelDepResolver.GetDependencies(a)
 	}
 	return nil, errors.New("unknown artifact type")
 }

--- a/pkg/skaffold/build/local.go
+++ b/pkg/skaffold/build/local.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/build/tag"
@@ -77,7 +78,8 @@ func (l *LocalBuilder) runBuildForArtifact(ctx context.Context, out io.Writer, a
 	if artifact.BazelArtifact != nil {
 		return l.buildBazel(ctx, out, artifact)
 	}
-	return "", errors.New("unknown artifact type")
+	artifact.DockerArtifact = config.DefaultDockerArtifact
+	return l.buildDocker(ctx, out, artifact)
 }
 
 // Build runs a docker build on the host and tags the resulting image with
@@ -145,7 +147,7 @@ func (l *LocalBuilder) buildBazel(ctx context.Context, out io.Writer, a *config.
 	tarPath := strings.TrimPrefix(a.BazelArtifact.BuildTarget, "//:")
 	//TODO(r2d4): strip off trailing .tar, even worse
 	imageTag := strings.TrimSuffix(tarPath, ".tar")
-	imageTar, err := os.Open(fmt.Sprintf("bazel-bin/%s", tarPath))
+	imageTar, err := os.Open(filepath.Join("bazel-bin", tarPath))
 	if err != nil {
 		return "", errors.Wrap(err, "opening image tarball")
 	}

--- a/pkg/skaffold/build/local.go
+++ b/pkg/skaffold/build/local.go
@@ -20,6 +20,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/build/tag"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/config"
@@ -66,6 +70,16 @@ func NewLocalBuilder(cfg *config.BuildConfig, kubeContext string) (*LocalBuilder
 	return l, nil
 }
 
+func (l *LocalBuilder) runBuildForArtifact(ctx context.Context, out io.Writer, artifact *config.Artifact) (string, error) {
+	if artifact.DockerArtifact != nil {
+		return l.buildDocker(ctx, out, artifact)
+	}
+	if artifact.BazelArtifact != nil {
+		return l.buildBazel(ctx, out, artifact)
+	}
+	return "", errors.New("unknown artifact type")
+}
+
 // Build runs a docker build on the host and tags the resulting image with
 // its checksum. It streams build progress to the writer argument.
 func (l *LocalBuilder) Build(ctx context.Context, out io.Writer, tagger tag.Tagger, artifacts []*config.Artifact) (*BuildResult, error) {
@@ -79,31 +93,78 @@ func (l *LocalBuilder) Build(ctx context.Context, out io.Writer, tagger tag.Tagg
 		Builds: []Build{},
 	}
 	for _, artifact := range artifacts {
-		var b Build
-		var err error
-		if artifact.DockerArtifact != nil {
-			b, err = l.buildDocker(ctx, out, tagger, artifact)
-			if err != nil {
-				return nil, errors.Wrap(err, "building docker image")
+		initialTag, err := l.runBuildForArtifact(ctx, out, artifact)
+		if err != nil {
+			return nil, errors.Wrap(err, "running build for artifact")
+		}
+
+		digest, err := docker.Digest(ctx, l.api, initialTag)
+		if err != nil {
+			return nil, errors.Wrapf(err, "build and tag: %s", initialTag)
+		}
+		if digest == "" {
+			return nil, fmt.Errorf("digest not found")
+		}
+		tag, err := tagger.GenerateFullyQualifiedImageName(".", &tag.TagOptions{
+			ImageName: artifact.ImageName,
+			Digest:    digest,
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "generating tag")
+		}
+		if err := l.api.ImageTag(ctx, initialTag, tag); err != nil {
+			return nil, errors.Wrap(err, "tagging image")
+		}
+		if _, err := io.WriteString(out, fmt.Sprintf("Successfully tagged %s\n", tag)); err != nil {
+			return nil, errors.Wrap(err, "writing tag status")
+		}
+		if !*l.LocalBuild.SkipPush {
+			if err := docker.RunPush(ctx, l.api, tag, out); err != nil {
+				return nil, errors.Wrap(err, "running push")
 			}
 		}
-		if artifact.BazelArtifact != nil {
-			b, err = l.buildBazel(ctx, out, tagger, artifact)
-			if err != nil {
-				return nil, errors.Wrap(err, "building bazel image")
-			}
-		}
-		res.Builds = append(res.Builds, b)
+
+		res.Builds = append(res.Builds, Build{
+			ImageName: artifact.ImageName,
+			Tag:       tag,
+			Artifact:  artifact,
+		})
 	}
 
 	return res, nil
 }
 
-func (l *LocalBuilder) buildBazel(ctx context.Context, out io.Writer, tagger tag.Tagger, a *config.Artifact) (Build, error) {
-	return Build{}, nil
+func (l *LocalBuilder) buildBazel(ctx context.Context, out io.Writer, a *config.Artifact) (string, error) {
+	cmd := exec.Command("bazel", "build", a.BazelArtifact.BuildTarget)
+	cmd.Stdout = out
+	cmd.Stderr = out
+	if err := cmd.Run(); err != nil {
+		return "", errors.Wrap(err, "running command")
+	}
+	//TODO(r2d4): strip off leading //:, bad
+	tarPath := strings.TrimPrefix(a.BazelArtifact.BuildTarget, "//:")
+	//TODO(r2d4): strip off trailing .tar, even worse
+	imageTag := strings.TrimSuffix(tarPath, ".tar")
+	imageTar, err := os.Open(fmt.Sprintf("bazel-bin/%s", tarPath))
+	if err != nil {
+		return "", errors.Wrap(err, "opening image tarball")
+	}
+	defer imageTar.Close()
+	resp, err := l.api.ImageLoad(ctx, imageTar, false)
+	if err != nil {
+		return "", errors.Wrap(err, "loading image into docker daemon")
+	}
+	defer resp.Body.Close()
+	respStr, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.Wrap(err, "reading from image load response")
+	}
+	out.Write(respStr)
+
+	return fmt.Sprintf("bazel:%s", imageTag), nil
 }
 
-func (l *LocalBuilder) buildDocker(ctx context.Context, out io.Writer, tagger tag.Tagger, a *config.Artifact) (Build, error) {
+func (l *LocalBuilder) buildDocker(ctx context.Context, out io.Writer, a *config.Artifact) (string, error) {
 	if a.DockerArtifact.DockerfilePath == "" {
 		a.DockerArtifact.DockerfilePath = constants.DefaultDockerfilePath
 	}
@@ -111,43 +172,13 @@ func (l *LocalBuilder) buildDocker(ctx context.Context, out io.Writer, tagger ta
 	err := docker.RunBuild(ctx, l.api, &docker.BuildOptions{
 		ImageName:   initialTag,
 		Dockerfile:  a.DockerArtifact.DockerfilePath,
-		ContextDir:  a.DockerArtifact.Workspace,
+		ContextDir:  a.Workspace,
 		ProgressBuf: out,
 		BuildBuf:    out,
 		BuildArgs:   a.DockerArtifact.BuildArgs,
 	})
 	if err != nil {
-		return Build{}, errors.Wrap(err, "running build")
+		return "", errors.Wrap(err, "running build")
 	}
-	digest, err := docker.Digest(ctx, l.api, initialTag)
-	if err != nil {
-		return Build{}, errors.Wrap(err, "build and tag")
-	}
-	if digest == "" {
-		return Build{}, fmt.Errorf("digest not found")
-	}
-	tag, err := tagger.GenerateFullyQualifiedImageName(".", &tag.TagOptions{
-		ImageName: a.ImageName,
-		Digest:    digest,
-	})
-	if err != nil {
-		return Build{}, errors.Wrap(err, "generating tag")
-	}
-	if err := l.api.ImageTag(ctx, fmt.Sprintf("%s:latest", initialTag), tag); err != nil {
-		return Build{}, errors.Wrap(err, "tagging image")
-	}
-	if _, err := io.WriteString(out, fmt.Sprintf("Successfully tagged %s\n", tag)); err != nil {
-		return Build{}, errors.Wrap(err, "writing tag status")
-	}
-	if !*l.LocalBuild.SkipPush {
-		if err := docker.RunPush(ctx, l.api, tag, out); err != nil {
-			return Build{}, errors.Wrap(err, "running push")
-		}
-	}
-
-	return Build{
-		ImageName: a.ImageName,
-		Tag:       tag,
-		Artifact:  a,
-	}, nil
+	return fmt.Sprintf("%s:latest", initialTag), nil
 }

--- a/pkg/skaffold/build/local_test.go
+++ b/pkg/skaffold/build/local_test.go
@@ -50,11 +50,17 @@ func (t testAuthHelper) GetAllAuthConfigs() (map[string]types.AuthConfig, error)
 var testImage1 = &config.Artifact{
 	ImageName: "gcr.io/test/image",
 	Workspace: "../../../testdata/docker",
+	ArtifactType: config.ArtifactType{
+		DockerArtifact: &config.DockerArtifact{},
+	},
 }
 
 var testImage2 = &config.Artifact{
 	ImageName: "gcr.io/test/image2",
 	Workspace: "../../../testdata/docker",
+	ArtifactType: config.ArtifactType{
+		DockerArtifact: &config.DockerArtifact{},
+	},
 }
 
 func TestLocalRun(t *testing.T) {
@@ -111,10 +117,16 @@ func TestLocalRun(t *testing.T) {
 					{
 						ImageName: "gcr.io/test/image",
 						Workspace: "../../../testdata/docker",
+						ArtifactType: config.ArtifactType{
+							DockerArtifact: &config.DockerArtifact{},
+						},
 					},
 					{
 						ImageName: "gcr.io/test/image2",
 						Workspace: "../../../testdata/docker",
+						ArtifactType: config.ArtifactType{
+							DockerArtifact: &config.DockerArtifact{},
+						},
 					},
 				},
 				BuildType: config.BuildType{
@@ -128,6 +140,9 @@ func TestLocalRun(t *testing.T) {
 				{
 					ImageName: "gcr.io/test/image",
 					Workspace: "../../../testdata/docker",
+					ArtifactType: config.ArtifactType{
+						DockerArtifact: &config.DockerArtifact{},
+					},
 				},
 			},
 			api: testutil.NewFakeImageAPIClient(map[string]string{}, &testutil.FakeImageAPIOptions{}),

--- a/pkg/skaffold/config/config.go
+++ b/pkg/skaffold/config/config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/constants"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -146,6 +147,10 @@ var DefaultRunSkaffoldConfig = &SkaffoldConfig{
 	Build: BuildConfig{
 		TagPolicy: TagPolicy{GitTagger: &GitTagger{}},
 	},
+}
+
+var DefaultDockerArtifact = &DockerArtifact{
+	DockerfilePath: constants.DefaultDockerfilePath,
 }
 
 // Parse reads from an io.Reader and unmarshals the result into a SkaffoldConfig.

--- a/pkg/skaffold/config/config.go
+++ b/pkg/skaffold/config/config.go
@@ -103,10 +103,9 @@ type HelmRelease struct {
 // Artifact represents items that need should be built, along with the context in which
 // they should be built.
 type Artifact struct {
-	ImageName      string             `yaml:"imageName"`
-	DockerfilePath string             `yaml:"dockerfilePath,omitempty"`
-	Workspace      string             `yaml:"workspace,omitempty"`
-	BuildArgs      map[string]*string `yaml:"buildArgs,omitempty"`
+	ImageName    string `yaml:"imageName"`
+	Workspace    string `yaml:"workspace,omitempty"`
+	ArtifactType `yaml:",inline"`
 }
 
 // Profile is additional configuration that overrides default
@@ -115,6 +114,20 @@ type Profile struct {
 	Name   string       `yaml:"name"`
 	Build  BuildConfig  `yaml:"build,omitempty"`
 	Deploy DeployConfig `yaml:"deploy,omitempty"`
+}
+
+type ArtifactType struct {
+	DockerArtifact *DockerArtifact `yaml:"docker"`
+	BazelArtifact  *BazelArtifact  `yaml:"bazel"`
+}
+
+type DockerArtifact struct {
+	DockerfilePath string             `yaml:"dockerfilePath,omitempty"`
+	BuildArgs      map[string]*string `yaml:"buildArgs,omitempty"`
+}
+
+type BazelArtifact struct {
+	BuildTarget string `yaml:"target"`
 }
 
 // DefaultDevSkaffoldConfig is a partial set of defaults for the SkaffoldConfig

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -113,7 +113,7 @@ func (k *KubectlDeployer) Deploy(ctx context.Context, out io.Writer, b *build.Bu
 
 func generateManifest(b build.Build) (string, error) {
 	logrus.Info("No manifests specified. Generating a deployment.")
-	dockerfilePath := filepath.Join(b.Artifact.Workspace, b.Artifact.DockerfilePath)
+	dockerfilePath := filepath.Join(b.Artifact.DockerArtifact.Workspace, b.Artifact.DockerArtifact.DockerfilePath)
 	r, err := os.Open(dockerfilePath)
 	if err != nil {
 		return "", errors.Wrap(err, "reading dockerfile")

--- a/pkg/skaffold/deploy/kubectl.go
+++ b/pkg/skaffold/deploy/kubectl.go
@@ -113,7 +113,7 @@ func (k *KubectlDeployer) Deploy(ctx context.Context, out io.Writer, b *build.Bu
 
 func generateManifest(b build.Build) (string, error) {
 	logrus.Info("No manifests specified. Generating a deployment.")
-	dockerfilePath := filepath.Join(b.Artifact.DockerArtifact.Workspace, b.Artifact.DockerArtifact.DockerfilePath)
+	dockerfilePath := filepath.Join(b.Artifact.Workspace, b.Artifact.DockerArtifact.DockerfilePath)
 	r, err := os.Open(dockerfilePath)
 	if err != nil {
 		return "", errors.Wrap(err, "reading dockerfile")

--- a/pkg/skaffold/docker/image.go
+++ b/pkg/skaffold/docker/image.go
@@ -103,8 +103,9 @@ func RunPush(ctx context.Context, cli DockerAPIClient, ref string, out io.Writer
 // The digest is of the form
 // sha256:<image_id>
 func Digest(ctx context.Context, cli DockerAPIClient, ref string) (string, error) {
-	refLatest := fmt.Sprintf("%s:latest", ref)
-	args := filters.KeyValuePair{Key: "reference", Value: refLatest}
+	// TODO(r2d4)
+	fmt.Printf("Digest: %s\n", ref)
+	args := filters.KeyValuePair{Key: "reference", Value: ref}
 	filters := filters.NewArgs(args)
 	imageList, err := cli.ImageList(ctx, types.ImageListOptions{
 		Filters: filters,
@@ -114,7 +115,7 @@ func Digest(ctx context.Context, cli DockerAPIClient, ref string) (string, error
 	}
 	for _, image := range imageList {
 		for _, tag := range image.RepoTags {
-			if tag == refLatest {
+			if tag == ref {
 				return image.ID, nil
 			}
 		}

--- a/pkg/skaffold/docker/image_test.go
+++ b/pkg/skaffold/docker/image_test.go
@@ -134,7 +134,7 @@ func TestDigest(t *testing.T) {
 	var tests = []testImageAPI{
 		{
 			description: "get digest",
-			imageName:   "identifier",
+			imageName:   "identifier:latest",
 			tagToImageID: map[string]string{
 				"identifier:latest": "sha256:123abc",
 			},

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -29,7 +29,6 @@ import (
 	"sync"
 
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/config"
-	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/util"
 	"github.com/containers/image/docker"
 	"github.com/containers/image/manifest"
@@ -56,12 +55,7 @@ var RetrieveImage = retrieveImage
 type DockerfileDepResolver struct{}
 
 func (*DockerfileDepResolver) GetDependencies(a *config.Artifact) ([]string, error) {
-	d := a.DockerArtifact
-	dockerfilePath := d.DockerfilePath
-	if d.DockerfilePath == "" {
-		dockerfilePath = constants.DefaultDockerfilePath
-	}
-	dockerfileAbsPath, err := filepath.Abs(filepath.Join(a.Workspace, dockerfilePath))
+	dockerfileAbsPath, err := filepath.Abs(filepath.Join(a.Workspace, a.DockerArtifact.DockerfilePath))
 	if err != nil {
 		return nil, errors.Wrap(err, "getting absolute path of dockerfile")
 	}

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -55,8 +55,6 @@ var RetrieveImage = retrieveImage
 
 type DockerfileDepResolver struct{}
 
-var DefaultDockerfileDepResolver = &DockerfileDepResolver{}
-
 func (*DockerfileDepResolver) GetDependencies(a *config.Artifact) ([]string, error) {
 	d := a.DockerArtifact
 	dockerfilePath := d.DockerfilePath

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -58,11 +58,12 @@ type DockerfileDepResolver struct{}
 var DefaultDockerfileDepResolver = &DockerfileDepResolver{}
 
 func (*DockerfileDepResolver) GetDependencies(a *config.Artifact) ([]string, error) {
-	dockerfilePath := a.DockerfilePath
-	if a.DockerfilePath == "" {
+	d := a.DockerArtifact
+	dockerfilePath := d.DockerfilePath
+	if d.DockerfilePath == "" {
 		dockerfilePath = constants.DefaultDockerfilePath
 	}
-	dockerfileAbsPath, err := filepath.Abs(filepath.Join(a.Workspace, dockerfilePath))
+	dockerfileAbsPath, err := filepath.Abs(filepath.Join(d.Workspace, dockerfilePath))
 	if err != nil {
 		return nil, errors.Wrap(err, "getting absolute path of dockerfile")
 	}
@@ -71,7 +72,7 @@ func (*DockerfileDepResolver) GetDependencies(a *config.Artifact) ([]string, err
 		return nil, errors.Wrap(err, "opening dockerfile")
 	}
 	defer f.Close()
-	deps, err := GetDockerfileDependencies(a.Workspace, f)
+	deps, err := GetDockerfileDependencies(d.Workspace, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting dockerfile dependencies")
 	}

--- a/pkg/skaffold/docker/parse.go
+++ b/pkg/skaffold/docker/parse.go
@@ -63,7 +63,7 @@ func (*DockerfileDepResolver) GetDependencies(a *config.Artifact) ([]string, err
 	if d.DockerfilePath == "" {
 		dockerfilePath = constants.DefaultDockerfilePath
 	}
-	dockerfileAbsPath, err := filepath.Abs(filepath.Join(d.Workspace, dockerfilePath))
+	dockerfileAbsPath, err := filepath.Abs(filepath.Join(a.Workspace, dockerfilePath))
 	if err != nil {
 		return nil, errors.Wrap(err, "getting absolute path of dockerfile")
 	}
@@ -72,7 +72,7 @@ func (*DockerfileDepResolver) GetDependencies(a *config.Artifact) ([]string, err
 		return nil, errors.Wrap(err, "opening dockerfile")
 	}
 	defer f.Close()
-	deps, err := GetDockerfileDependencies(d.Workspace, f)
+	deps, err := GetDockerfileDependencies(a.Workspace, f)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting dockerfile dependencies")
 	}

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -26,7 +26,6 @@ import (
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/config"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/constants"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/deploy"
-	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/docker"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/kubernetes"
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/watch"
 	clientgo "k8s.io/client-go/kubernetes"
@@ -139,7 +138,7 @@ func (r *SkaffoldRunner) Run() error {
 
 func (r *SkaffoldRunner) dev(ctx context.Context, artifacts []*config.Artifact) error {
 	var err error
-	r.depMap, err = build.NewDependencyMap(artifacts, docker.DefaultDockerfileDepResolver)
+	r.depMap, err = build.NewDependencyMap(artifacts)
 	if err != nil {
 		return errors.Wrap(err, "getting path to dependency map")
 	}


### PR DESCRIPTION
This is a PR on top of #273 

The build stanza has changed yet again

ImageName and Workspace still live at the top level, but now there is additional information on how to build.
```golang
type Artifact struct {
	ImageName    string `yaml:"imageName"`
	Workspace    string `yaml:"workspace"`
	ArtifactType `yaml:",inline"`
}
type DockerArtifact struct {
	DockerfilePath string             `yaml:"dockerfilePath"`
	BuildArgs      map[string]*string `yaml:"buildArgs"`
}

type BazelArtifact struct {
	BuildTarget string `yaml:"target"`
}
```

The added bonus is that you can build multiple artifact types in the same YAML. I'm not sure that matters though. 

The question is where the `local: {}` or `googleCloudBuild: {}` should go. In a sense, this part is responsible for how the actual build is made accessible to the cluster. I see no reason why we can't implement similar logic in googleCloudBuild to build non-docker artifacts (although it would be in docker!).

local:{} encodes the information of how to get the image into either minikube, docker for desktop, or a remote cluster, which is still essential regardless of how you build the image.

```
build:
  artifacts:
  - imageName: gcr.io/k8s-skaffold/skaffold-example
    workspace: .
    docker: {}
```

To try out this PR, you'll need bazel installed and you can change directories to `examples/bazel` and run a `skaffold run` or `skaffold dev`.

As another added bonus, this is a nice filewatcher frontend for bazel projects too.

