### PR TITLE
Add an environment variable template tagger.

### DIFF
--- a/examples/annotated-skaffold.yaml
+++ b/examples/annotated-skaffold.yaml
@@ -5,8 +5,17 @@ build:
   # we provide a few strategies here, although you most likely won't need to care!
   # Valid values for tagPolicy are
   #
-  # sha256: {}    - tags the image with the checksum of the built image (image id)
-  # gitCommit: {} - tags the image with the git commit of your current repository
+  # sha256 tags the image with the checksum of the built image (image id)
+  # sha256: {}
+  # gitCommit tags the image with the git commit of your current repository
+  # gitCommit: {}
+  # envTemplate tags the image with a configurable template string.
+  # The template string must be in the golang text/template syntax: https://golang.org/pkg/text/template/
+  # The template is compiled and executed against the current environment, with two automatic variables injected:
+  #   - IMAGE_NAME: The name of the image being built, as supplied in the artifacts section
+  #   - DIGETST: The digest of the newly built image.
+  # envTemplate: - 
+  #   template: "{{.RELEASE}}-{{.IMAGE_NAME}}"
   
   # tagPolicy:
   #   sha256: {}

--- a/examples/environment-variables/Dockerfile
+++ b/examples/environment-variables/Dockerfile
@@ -1,0 +1,6 @@
+FROM golang:1.9.4-alpine3.7
+
+WORKDIR /go/src/github.com/GoogleCloudPlatform/skaffold/examples/getting-started
+CMD ["./app"]
+COPY main.go .
+RUN go build -o app main.go

--- a/examples/environment-variables/k8s-pod.yaml
+++ b/examples/environment-variables/k8s-pod.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: getting-started
+spec:
+  containers:
+  - name: getting-started
+    image: gcr.io/k8s-skaffold/skaffold-example-foo

--- a/examples/environment-variables/main.go
+++ b/examples/environment-variables/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	for {
+		fmt.Println("Hello world!")
+		time.Sleep(time.Second * 1)
+	}
+}

--- a/examples/environment-variables/skaffold-env-tag.yaml
+++ b/examples/environment-variables/skaffold-env-tag.yaml
@@ -1,0 +1,14 @@
+apiVersion: skaffold/v1alpha2
+kind: Config
+build:
+  tagPolicy:
+    envTemplate:
+      template: "{{.IMAGE_NAME}}-{{.FOO}}"
+  artifacts:
+  - imageName: gcr.io/k8s-skaffold/skaffold-example
+    workspace: .
+  local: {}
+deploy:
+  kubectl:
+    manifests:
+      - k8s-*

--- a/examples/environment-variables/skaffold.yaml
+++ b/examples/environment-variables/skaffold.yaml
@@ -1,0 +1,16 @@
+apiVersion: skaffold/v1alpha2
+kind: Config
+build:
+  artifacts:
+  - imageName: gcr.io/k8s-skaffold/skaffold-example
+    workspace: .
+  local: {}
+deploy:
+  kubectl:
+    manifests:
+      - k8s-pod.yaml
+profiles:
+  - name: gcb
+    build:
+      googleCloudBuild:
+        projectId: k8s-skaffold

--- a/integration/run_test.go
+++ b/integration/run_test.go
@@ -20,6 +20,7 @@ package integration
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"os/exec"
 	"testing"
@@ -70,6 +71,7 @@ func TestRun(t *testing.T) {
 		extraArgs   []string
 		deployments []testObject
 		pods        []testObject
+		env         map[string]string
 
 		remoteOnly bool
 	}
@@ -106,6 +108,18 @@ func TestRun(t *testing.T) {
 			dir:       "../examples",
 			extraArgs: []string{"-f", "annotated-skaffold.yaml"},
 		},
+		{
+			description: "getting-started envTagger",
+			pods: []testObject{
+				{
+					name:      "getting-started",
+					namespace: "default",
+				},
+			},
+			dir:       "../examples/environment-variables",
+			extraArgs: []string{"-f", "skaffold-env-tag.yaml"},
+			env:       map[string]string{"FOO": "foo"},
+		},
 		// // Don't run this test for now. It takes awhile to download all the
 		// // dependencies
 		// {
@@ -140,6 +154,11 @@ func TestRun(t *testing.T) {
 			args := []string{"run"}
 			args = append(args, testCase.extraArgs...)
 			cmd := exec.Command("skaffold", args...)
+			env := os.Environ()
+			for k, v := range testCase.env {
+				env = append(env, fmt.Sprintf("%s=%s", k, v))
+			}
+			cmd.Env = env
 			cmd.Dir = testCase.dir
 			out, outerr, err := util.RunCommand(cmd, nil)
 			if err != nil {

--- a/pkg/skaffold/build/tag/env_template.go
+++ b/pkg/skaffold/build/tag/env_template.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tag
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/pkg/errors"
+)
+
+// EnvTemplateTagger implements Tag
+type EnvTemplateTagger struct {
+	Template *template.Template
+}
+
+// For testing
+var environ = os.Environ
+
+// NewEnvTemplateTagger creates a new EnvTemplateTagger
+func NewEnvTemplateTagger(t string) (*EnvTemplateTagger, error) {
+	tmpl, err := template.New("envTemplate").Parse(t)
+	if err != nil {
+		return nil, errors.Wrap(err, "parsing template")
+	}
+	return &EnvTemplateTagger{
+		Template: tmpl,
+	}, nil
+}
+
+// GenerateFullyQualifiedImageName tags an image with the custom tag
+func (c *EnvTemplateTagger) GenerateFullyQualifiedImageName(workingDir string, opts *TagOptions) (string, error) {
+	var buf bytes.Buffer
+	envMap := map[string]string{}
+	for _, env := range environ() {
+		kvp := strings.SplitN(env, "=", 2)
+		if len(kvp) != 2 {
+			return "", fmt.Errorf("error parsing environment variables, %s does not contain an =", kvp)
+		}
+		envMap[kvp[0]] = kvp[1]
+	}
+
+	envMap["IMAGE_NAME"] = opts.ImageName
+	envMap["DIGEST"] = opts.Digest
+
+	logrus.Debugf("Executing template %v with environment %v", c.Template, envMap)
+	if err := c.Template.Execute(&buf, envMap); err != nil {
+		return "", errors.Wrap(err, "executing template")
+	}
+	return buf.String(), nil
+}

--- a/pkg/skaffold/build/tag/env_template_test.go
+++ b/pkg/skaffold/build/tag/env_template_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tag
+
+import (
+	"testing"
+	"text/template"
+)
+
+func TestEnvTemplateTagger_GenerateFullyQualifiedImageName(t *testing.T) {
+	type fields struct {
+		Template string
+	}
+	type args struct {
+		opts *TagOptions
+		env  []string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "empty env",
+			fields: fields{
+				Template: "{{.IMAGE_NAME}}:{{.DIGEST}}",
+			},
+			args: args{
+				opts: &TagOptions{
+					ImageName: "foo",
+					Digest:    "bar",
+				},
+			},
+			want: "foo:bar",
+		},
+		{
+			name: "env",
+			fields: fields{
+				Template: "{{.FOO}}-{{.BAZ}}:latest",
+			},
+			args: args{
+				env: []string{"FOO=BAR", "BAZ=BAT"},
+				opts: &TagOptions{
+					ImageName: "foo",
+					Digest:    "bar",
+				},
+			},
+			want: "BAR-BAT:latest",
+		},
+		{
+			name: "opts precedence",
+			fields: fields{
+				Template: "{{.IMAGE_NAME}}-{{.FROM_ENV}}:latest",
+			},
+			args: args{
+				env: []string{"FROM_ENV=FOO", "IMAGE_NAME=BAT"},
+				opts: &TagOptions{
+					ImageName: "image_name",
+					Digest:    "bar",
+				},
+			},
+			want: "image_name-FOO:latest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt := tt
+			t.Parallel()
+			c := &EnvTemplateTagger{
+				Template: template.Must(template.New("").Parse(tt.fields.Template)),
+			}
+			environ = func() []string {
+				return tt.args.env
+			}
+			got, err := c.GenerateFullyQualifiedImageName("", tt.args.opts)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("EnvTemplateTagger.GenerateFullyQualifiedImageName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("EnvTemplateTagger.GenerateFullyQualifiedImageName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewEnvTemplateTagger(t *testing.T) {
+	type args struct {
+		t string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid template",
+			args: args{
+				t: "{{.FOO}}",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid template",
+			args: args{
+				t: "{{.FOO",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewEnvTemplateTagger(tt.args.t)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewEnvTemplateTagger() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/pkg/skaffold/config/config.go
+++ b/pkg/skaffold/config/config.go
@@ -42,8 +42,9 @@ type BuildConfig struct {
 
 // TagPolicy contains all the configuration for the tagging step
 type TagPolicy struct {
-	GitTagger *GitTagger `yaml:"git"`
-	ShaTagger *ShaTagger `yaml:"sha256"`
+	GitTagger         *GitTagger         `yaml:"git"`
+	ShaTagger         *ShaTagger         `yaml:"sha256"`
+	EnvTemplateTagger *EnvTemplateTagger `yaml:"envTemplate"`
 }
 
 // ShaTagger contains the configuration for the SHA tagger.
@@ -51,6 +52,11 @@ type ShaTagger struct{}
 
 // GitTagger contains the configuration for the git tagger.
 type GitTagger struct{}
+
+// EnvTemplateTagger contains the configuration for the envTemplate tagger.
+type EnvTemplateTagger struct {
+	Template string `yaml:"template"`
+}
 
 // BuildType contains the specific implementation and parameters needed
 // for the build step. Only one field should be populated.

--- a/pkg/skaffold/runner/runner.go
+++ b/pkg/skaffold/runner/runner.go
@@ -115,6 +115,9 @@ func getDeployer(cfg *config.DeployConfig, kubeContext string) (deploy.Deployer,
 }
 
 func newTaggerForConfig(t config.TagPolicy) (tag.Tagger, error) {
+	if t.EnvTemplateTagger != nil {
+		return tag.NewEnvTemplateTagger(t.EnvTemplateTagger.Template)
+	}
 	if t.ShaTagger != nil {
 		return &tag.ChecksumTagger{}, nil
 	}


### PR DESCRIPTION
There was a bug/documentation issue with the existing tagPolicy struct. it should not have been inline.

Tests are coming, i want to get some feedback on the interface first.

This allows users to specify a golang template string that uses the Environment to generate tags for images.

I also merge in the opts.TagOptions values as well, for multi-image scenarios. This needs to be documented.