### PR TITLE
Remove duplicate error

### DIFF
--- a/cmd/skaffold/skaffold.go
+++ b/cmd/skaffold/skaffold.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/GoogleCloudPlatform/skaffold/cmd/skaffold/app"
@@ -25,7 +24,6 @@ import (
 
 func main() {
 	if err := app.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		os.Exit(1)
 	}
 	os.Exit(0)


### PR DESCRIPTION
Signed-off-by: David Gageot <david@gageot.net>

eg:
```
skaffold dev -f unknown
Error: read skaffold config: open unknown: no such file or directory
Usage:
  skaffold dev [flags]

Flags:
  -f, --filename string       Filename or URL to the pipeline file (default "skaffold.yaml")
  -h, --help                  help for dev
  -p, --profile stringArray   Activate profiles by name
      --toot                  Emit a terminal beep after the deploy is complete

Global Flags:
  -v, --verbosity string   Log level (debug, info, warn, error, fatal, panic (default "warning")

error: read skaffold config: open unknown: no such file or directory
```