### PR TITLE
add support for multi-stage build in getting-started example

### DIFF
--- a/examples/getting-started/Dockerfile
+++ b/examples/getting-started/Dockerfile
@@ -1,6 +1,8 @@
-FROM golang:1.9.4-alpine3.7
-
+FROM golang:1.9.4-alpine3.7 as builder
 WORKDIR /go/src/github.com/GoogleCloudPlatform/skaffold/examples/getting-started
-CMD ["./app"]
 COPY main.go .
 RUN go build -o app main.go
+
+FROM alpine:latest  
+CMD ["./app"]
+COPY --from=builder /go/src/github.com/GoogleCloudPlatform/skaffold/examples/getting-started/app .


### PR DESCRIPTION
Add multi-stage build format for getting-started Dockerfile, which resolves #393. 

Signed-off-by: zanetworker <adel.zalok.89@gmail.com>