### PR TITLE
Move over the rest of testutil to use cmp.Diff fixes #382

### DIFF
--- a/pkg/skaffold/build/deps_test.go
+++ b/pkg/skaffold/build/deps_test.go
@@ -16,10 +16,10 @@ limitations under the License.
 package build
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/schema/v1alpha2"
+	"github.com/google/go-cmp/cmp"
 )
 
 type FakeDependencyResolver struct {
@@ -82,7 +82,7 @@ func TestPaths(t *testing.T) {
 			DefaultDockerfileDepResolver = oldDockerResolver
 			DefaultBazelDepResolver = oldBazelResolver
 
-			if !reflect.DeepEqual(test.expected, m.Paths()) {
+			if diff := cmp.Diff(test.expected, m.Paths()); diff != "" {
 				t.Errorf("%T differ.\nExpected\n%+v\nActual\n%+v", test.expected, test.expected, m.Paths())
 				return
 			}

--- a/pkg/skaffold/docker/parse_test.go
+++ b/pkg/skaffold/docker/parse_test.go
@@ -19,13 +19,13 @@ package docker
 import (
 	"fmt"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/skaffold/pkg/skaffold/util"
 	"github.com/GoogleCloudPlatform/skaffold/testutil"
 	"github.com/containers/image/manifest"
+	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/afero"
 )
 
@@ -327,7 +327,7 @@ func TestPortsFromDockerfile(t *testing.T) {
 				t.Errorf("PortsFromDockerfile() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !reflect.DeepEqual(got, tt.want) {
+			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("PortsFromDockerfile() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/skaffold/watch/watch_test.go
+++ b/pkg/skaffold/watch/watch_test.go
@@ -19,10 +19,10 @@ import (
 	"context"
 	"io/ioutil"
 	"path/filepath"
-	"reflect"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/skaffold/testutil"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestWatch(t *testing.T) {
@@ -89,7 +89,7 @@ func TestWatch(t *testing.T) {
 
 				expected := prependParentDir(tmp, test.expectedChanges)
 
-				if !reflect.DeepEqual(expected, actual) {
+				if diff := cmp.Diff(expected, actual); diff != "" {
 					t.Errorf("Expected %+v, Actual %+v", expected, actual)
 				}
 			})


### PR DESCRIPTION
Changed to `cmp.Diff`. Unit tests run successfully.